### PR TITLE
feat(payments): Hubtel config API, billing codes, and payer-facing UX

### DIFF
--- a/backend/docs/integrations.json
+++ b/backend/docs/integrations.json
@@ -37,20 +37,42 @@
     },
     "/api/v1/integrations/hubtel/fulfilment": {
       "post": {
-        "operationId": "HubtelController_fulfilment",
+        "operationId": "HubtelController_fulfilmentStub",
         "parameters": [],
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        },
+        "summary": "Legacy fulfilment stub (200 OK, no processing)",
+        "tags": ["Hubtel Integrations"]
+      }
+    },
+    "/api/v1/integrations/hubtel/receive-money/callback/{schoolId}": {
+      "post": {
+        "operationId": "HubtelDirectReceiveController_receiveMoneyCallback",
+        "parameters": [
+          {
+            "name": "schoolId",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
         "requestBody": {
           "required": true,
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/HubtelFulfilmentRequestDto"
+                "$ref": "#/components/schemas/HubtelReceiveMoneyCallbackDto"
               }
             }
           }
         },
         "responses": {
-          "201": {
+          "200": {
             "description": ""
           }
         },
@@ -91,6 +113,10 @@
           "Platform": {
             "type": "string",
             "enum": ["USSD", "Webstore", "Hubtel-App"]
+          },
+          "MetaData": {
+            "type": "object",
+            "nullable": true
           }
         },
         "required": [
@@ -105,129 +131,62 @@
           "Platform"
         ]
       },
-      "HubtelFulfilmentRequestDto": {
+      "HubtelReceiveMoneyCallbackDto": {
         "type": "object",
         "properties": {
-          "SessionId": {
+          "ResponseCode": {
+            "type": "string",
+            "description": "Hubtel response code (e.g. 0000, 2001)"
+          },
+          "Message": {
             "type": "string"
           },
-          "OrderId": {
-            "type": "string"
-          },
-          "ExtraData": {
-            "type": "object"
-          },
-          "OrderInfo": {
-            "$ref": "#/components/schemas/HubtelOrderInfoDto"
+          "Data": {
+            "$ref": "#/components/schemas/HubtelReceiveMoneyCallbackDataDto"
           }
         },
-        "required": ["SessionId", "OrderId", "ExtraData", "OrderInfo"]
+        "required": ["ResponseCode", "Data"]
       },
-      "HubtelOrderInfoDto": {
+      "HubtelReceiveMoneyCallbackDataDto": {
         "type": "object",
         "properties": {
-          "CustomerMobileNumber": {
-            "type": "string"
-          },
-          "CustomerEmail": {
-            "type": "object"
-          },
-          "CustomerName": {
-            "type": "string"
-          },
-          "Status": {
-            "type": "string"
-          },
-          "OrderDate": {
-            "type": "string"
-          },
-          "Currency": {
-            "type": "string"
-          },
-          "BranchName": {
-            "type": "string"
-          },
-          "IsRecurring": {
-            "type": "boolean"
-          },
-          "RecurringInvoiceId": {
-            "type": "object"
-          },
-          "Subtotal": {
+          "Amount": {
             "type": "number"
           },
-          "Items": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/HubtelFulfilmentItemDto"
-            }
-          },
-          "Payment": {
-            "$ref": "#/components/schemas/HubtelFulfilmentPaymentDto"
-          }
-        },
-        "required": [
-          "CustomerMobileNumber",
-          "CustomerEmail",
-          "CustomerName",
-          "Status",
-          "OrderDate",
-          "Currency",
-          "BranchName",
-          "IsRecurring",
-          "RecurringInvoiceId",
-          "Subtotal",
-          "Items",
-          "Payment"
-        ]
-      },
-      "HubtelFulfilmentItemDto": {
-        "type": "object",
-        "properties": {
-          "ItemId": {
-            "type": "string"
-          },
-          "Name": {
-            "type": "string"
-          },
-          "Quantity": {
-            "type": "number"
-          },
-          "UnitPrice": {
-            "type": "number"
-          }
-        },
-        "required": ["ItemId", "Name", "Quantity", "UnitPrice"]
-      },
-      "HubtelFulfilmentPaymentDto": {
-        "type": "object",
-        "properties": {
-          "PaymentType": {
-            "type": "string"
-          },
-          "AmountPaid": {
+          "Charges": {
             "type": "number"
           },
           "AmountAfterCharges": {
             "type": "number"
           },
+          "AmountCharged": {
+            "type": "number"
+          },
+          "Description": {
+            "type": "string"
+          },
+          "ClientReference": {
+            "type": "string"
+          },
+          "TransactionId": {
+            "type": "string"
+          },
+          "ExternalTransactionId": {
+            "type": "string"
+          },
+          "OrderId": {
+            "type": "string"
+          },
           "PaymentDate": {
             "type": "string"
-          },
-          "PaymentDescription": {
-            "type": "string"
-          },
-          "IsSuccessful": {
-            "type": "boolean"
           }
         },
         "required": [
-          "PaymentType",
-          "AmountPaid",
+          "Amount",
+          "Charges",
           "AmountAfterCharges",
-          "PaymentDate",
-          "PaymentDescription",
-          "IsSuccessful"
+          "ClientReference",
+          "TransactionId"
         ]
       }
     }

--- a/backend/docs/payments.json
+++ b/backend/docs/payments.json
@@ -66,6 +66,14 @@
             }
           },
           {
+            "name": "feeStructureId",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
             "name": "dateFrom",
             "required": false,
             "in": "query",
@@ -87,6 +95,19 @@
             "description": ""
           }
         },
+        "tags": ["Payments"]
+      }
+    },
+    "/api/v1/payments/my-school/config": {
+      "get": {
+        "operationId": "PaymentsController_getSchoolPaymentConfig",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        },
+        "summary": "Hubtel payment readiness for your school",
         "tags": ["Payments"]
       }
     },
@@ -164,6 +185,14 @@
             }
           },
           {
+            "name": "feeStructureId",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
             "name": "dateFrom",
             "required": false,
             "in": "query",
@@ -188,6 +217,19 @@
         "tags": ["Payments"]
       }
     },
+    "/api/v1/payments/me/config": {
+      "get": {
+        "operationId": "PaymentsController_getMyPaymentConfig",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        },
+        "summary": "Hubtel payment readiness for your school",
+        "tags": ["Payments"]
+      }
+    },
     "/api/v1/payments/me/{transactionId}/receipt": {
       "get": {
         "operationId": "PaymentsController_getMyReceipt",
@@ -207,6 +249,139 @@
           }
         },
         "tags": ["Payments"]
+      }
+    },
+    "/api/v1/payments/public/initiate": {
+      "post": {
+        "operationId": "PublicPaymentController_initiate",
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/StudentInitiatePaymentDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": ""
+          }
+        },
+        "security": [
+          {
+            "bearer": []
+          }
+        ],
+        "summary": "Send payment OTP via SMS (logged-in student only)",
+        "tags": ["Student payments (OTP checkout)"]
+      }
+    },
+    "/api/v1/payments/public/verify-and-pay": {
+      "post": {
+        "operationId": "PublicPaymentController_verifyAndPay",
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/VerifyAndPayPublicPaymentDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": ""
+          }
+        },
+        "security": [
+          {
+            "bearer": []
+          }
+        ],
+        "summary": "Verify OTP and trigger Hubtel Direct Receive for your school",
+        "tags": ["Student payments (OTP checkout)"]
+      }
+    },
+    "/api/v1/payments/public/status/{clientReference}": {
+      "get": {
+        "operationId": "PublicPaymentController_status",
+        "parameters": [
+          {
+            "name": "clientReference",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        },
+        "security": [
+          {
+            "bearer": []
+          }
+        ],
+        "summary": "Payment status for your transaction only",
+        "tags": ["Student payments (OTP checkout)"]
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "StudentInitiatePaymentDto": {
+        "type": "object",
+        "properties": {
+          "amount": {
+            "type": "number",
+            "description": "Amount in GHS (max 2 decimal places)",
+            "example": 50
+          },
+          "mobileNumber": {
+            "type": "string",
+            "description": "Customer's mobile money number in international format (e.g. 233249111411)",
+            "example": "233249111411"
+          },
+          "channel": {
+            "type": "string",
+            "enum": ["mtn-gh", "vodafone-gh", "tigo-gh"]
+          },
+          "targetFeeStructureId": {
+            "type": "string",
+            "description": "Optional fee structure id to prioritise during allocation when payment is fulfilled"
+          },
+          "customerName": {
+            "type": "string",
+            "description": "Optional payer display name"
+          },
+          "customerEmail": {
+            "type": "string",
+            "description": "Optional payer email"
+          }
+        },
+        "required": ["amount", "mobileNumber", "channel"]
+      },
+      "VerifyAndPayPublicPaymentDto": {
+        "type": "object",
+        "properties": {
+          "otpRequestId": {
+            "type": "string",
+            "description": "OTP request id returned from /initiate"
+          },
+          "otp": {
+            "type": "string",
+            "description": "6-digit OTP code"
+          }
+        },
+        "required": ["otpRequestId", "otp"]
       }
     }
   },

--- a/backend/docs/school.json
+++ b/backend/docs/school.json
@@ -143,6 +143,75 @@
         "tags": ["School"]
       }
     },
+    "/api/v1/schools/{id}/hubtel-merchant": {
+      "get": {
+        "operationId": "SchoolController_getHubtelMerchant",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        },
+        "tags": ["School"]
+      },
+      "put": {
+        "operationId": "SchoolController_setHubtelMerchant",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateHubtelMerchantDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        },
+        "tags": ["School"]
+      },
+      "delete": {
+        "operationId": "SchoolController_clearHubtelMerchant",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        },
+        "tags": ["School"]
+      }
+    },
     "/api/v1/schools/update-grading-percentages": {
       "put": {
         "operationId": "SchoolController_updateGradingPercentages",
@@ -204,6 +273,30 @@
           }
         },
         "required": ["calendlyUrl", "schoolId"]
+      },
+      "UpdateHubtelMerchantDto": {
+        "type": "object",
+        "properties": {
+          "clientId": {
+            "type": "string",
+            "description": "Hubtel API client id (Basic Auth username)"
+          },
+          "clientSecret": {
+            "type": "string",
+            "description": "Hubtel API client secret (Basic Auth password)"
+          },
+          "collectionAccountNumber": {
+            "type": "string",
+            "description": "School's Hubtel Collection Account Number (used in URL path; determines settlement merchant)",
+            "example": "11684"
+          },
+          "active": {
+            "type": "boolean",
+            "description": "Whether the merchant configuration is active and may receive payments",
+            "default": true
+          }
+        },
+        "required": ["clientId", "clientSecret", "collectionAccountNumber"]
       },
       "UpdateGradingPercentagesDto": {
         "type": "object",

--- a/backend/docs/schools.json
+++ b/backend/docs/schools.json
@@ -143,6 +143,75 @@
         "tags": ["School"]
       }
     },
+    "/api/v1/schools/{id}/hubtel-merchant": {
+      "get": {
+        "operationId": "SchoolController_getHubtelMerchant",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        },
+        "tags": ["School"]
+      },
+      "put": {
+        "operationId": "SchoolController_setHubtelMerchant",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateHubtelMerchantDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        },
+        "tags": ["School"]
+      },
+      "delete": {
+        "operationId": "SchoolController_clearHubtelMerchant",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        },
+        "tags": ["School"]
+      }
+    },
     "/api/v1/schools/update-grading-percentages": {
       "put": {
         "operationId": "SchoolController_updateGradingPercentages",
@@ -204,6 +273,30 @@
           }
         },
         "required": ["calendlyUrl", "schoolId"]
+      },
+      "UpdateHubtelMerchantDto": {
+        "type": "object",
+        "properties": {
+          "clientId": {
+            "type": "string",
+            "description": "Hubtel API client id (Basic Auth username)"
+          },
+          "clientSecret": {
+            "type": "string",
+            "description": "Hubtel API client secret (Basic Auth password)"
+          },
+          "collectionAccountNumber": {
+            "type": "string",
+            "description": "School's Hubtel Collection Account Number (used in URL path; determines settlement merchant)",
+            "example": "11684"
+          },
+          "active": {
+            "type": "boolean",
+            "description": "Whether the merchant configuration is active and may receive payments",
+            "default": true
+          }
+        },
+        "required": ["clientId", "clientSecret", "collectionAccountNumber"]
       },
       "UpdateGradingPercentagesDto": {
         "type": "object",

--- a/backend/docs/student.json
+++ b/backend/docs/student.json
@@ -296,12 +296,12 @@
       "ForgotStudentPasswordDto": {
         "type": "object",
         "properties": {
-          "email": {
+          "identifier": {
             "type": "string",
-            "example": "student@school.com"
+            "example": "student@school.com or STU-2024-001"
           }
         },
-        "required": ["email"]
+        "required": ["identifier"]
       },
       "UpdateProfileDto": {
         "type": "object",

--- a/backend/docs/teacher.json
+++ b/backend/docs/teacher.json
@@ -881,12 +881,12 @@
       "ForgotTeacherPasswordDto": {
         "type": "object",
         "properties": {
-          "email": {
+          "identifier": {
             "type": "string",
-            "example": "teacher@school.com"
+            "example": "teacher@school.com or TCH-001"
           }
         },
-        "required": ["email"]
+        "required": ["identifier"]
       },
       "UpdateProfileDto": {
         "type": "object",

--- a/backend/src/integrations/hubtel/hubtel-response-codes.ts
+++ b/backend/src/integrations/hubtel/hubtel-response-codes.ts
@@ -1,5 +1,6 @@
 import { PaymentTransactionStatus } from 'src/payments/entities/payment-transaction.entity';
 
+/** Internal / logs / DB provider status — not shown to end users. */
 export const HUBTEL_RESPONSE_CODE_DESCRIPTIONS: Record<string, string> = {
   '0000': 'Transaction processed successfully',
   '0001': 'Request accepted; awaiting final state via callback',
@@ -13,6 +14,24 @@ export const HUBTEL_RESPONSE_CODE_DESCRIPTIONS: Record<string, string> = {
   '4103': 'Permission denied; account not allowed to transact on this channel',
 };
 
+/** Short messages for USSD / apps — no implementation details. */
+const HUBTEL_USER_FACING_MESSAGES: Record<string, string> = {
+  '2001': 'Could not charge your wallet.\nCheck balance or PIN and try again.',
+  '4000': 'Service unavailable.\nTry again later.',
+  '4070': 'This payment is not available.\nContact your school.',
+  '4101': 'School not accepting payments yet.\nTry again later.',
+  '4103': 'This payment option is not available.\nTry another method.',
+};
+
+const USER_FACING_FALLBACK = 'Could not complete payment.\nTry again later.';
+
+export function userFacingMessageForHubtelResponseCode(
+  responseCode: string | number | null | undefined,
+): string {
+  const code = String(responseCode ?? '').trim();
+  return HUBTEL_USER_FACING_MESSAGES[code] ?? USER_FACING_FALLBACK;
+}
+
 const MERCHANT_CONFIG_ERROR_CODES = new Set(['4070', '4101', '4103']);
 
 export type HubtelOutcome =
@@ -23,6 +42,7 @@ export type HubtelOutcome =
       status: PaymentTransactionStatus.FAILED;
       isMerchantConfig: boolean;
       reason: string;
+      responseCode: string;
     };
 
 export function mapHubtelResponseCode(
@@ -47,5 +67,6 @@ export function mapHubtelResponseCode(
     status: PaymentTransactionStatus.FAILED,
     isMerchantConfig: MERCHANT_CONFIG_ERROR_CODES.has(code),
     reason: description,
+    responseCode: code,
   };
 }

--- a/backend/src/integrations/hubtel/hubtel.service.ts
+++ b/backend/src/integrations/hubtel/hubtel.service.ts
@@ -12,6 +12,7 @@ import {
 import { PaymentTransactionStatus } from 'src/payments/entities/payment-transaction.entity';
 import { Student } from 'src/student/student.entity';
 import { HubtelDirectReceiveService } from './hubtel-direct-receive.service';
+import { userFacingMessageForHubtelResponseCode } from './hubtel-response-codes';
 import { resolveHubtelChannelFromUssd } from './ussd-operator.util';
 import {
   buildShortStudentDisplayName,
@@ -187,7 +188,7 @@ export class HubtelService {
         this.buildResponse(payload.SessionId, {
           Type: HubtelResponseType.RESPONSE,
           Message: truncateToUssdLimit(
-            'Enter student ID or billing code\n0. Back',
+            'Enter student ID or 6-digit billing code\n0. Back',
           ),
           Label: 'Student',
           DataType: HubtelDataType.INPUT,
@@ -202,7 +203,7 @@ export class HubtelService {
         this.buildResponse(payload.SessionId, {
           Type: HubtelResponseType.RESPONSE,
           Message: truncateToUssdLimit(
-            'Enter student ID or billing code\n0. Back',
+            'Enter student ID or 6-digit billing code\n0. Back',
           ),
           Label: 'Student',
           DataType: HubtelDataType.INPUT,
@@ -246,7 +247,7 @@ export class HubtelService {
       return this.buildResponse(payload.SessionId, {
         Type: HubtelResponseType.RESPONSE,
         Message: truncateToUssdLimit(
-          'Enter student ID or billing code\n0. Back',
+          'Enter student ID or 6-digit billing code\n0. Back',
         ),
         Label: 'Student',
         DataType: HubtelDataType.INPUT,
@@ -355,7 +356,7 @@ export class HubtelService {
       return this.buildResponse(payload.SessionId, {
         Type: HubtelResponseType.RESPONSE,
         Message: truncateToUssdLimit(
-          'Enter student ID or billing code\n0. Back',
+          'Enter student ID or 6-digit billing code\n0. Back',
         ),
         Label: 'Student',
         DataType: HubtelDataType.INPUT,
@@ -515,7 +516,7 @@ export class HubtelService {
       return this.buildResponse(payload.SessionId, {
         Type: HubtelResponseType.RESPONSE,
         Message: truncateToUssdLimit(
-          'Enter student ID or billing code\n0. Back',
+          'Enter student ID or 6-digit billing code\n0. Back',
         ),
         Label: 'Student',
         DataType: HubtelDataType.INPUT,
@@ -706,10 +707,10 @@ export class HubtelService {
         outcome.reason,
         rawResponse as Record<string, unknown>,
       );
-      return this.release(
-        payload,
-        truncateToUssdLimit(`Payment failed.\n${outcome.reason}`),
+      const userMsg = userFacingMessageForHubtelResponseCode(
+        outcome.responseCode,
       );
+      return this.release(payload, truncateToUssdLimit(userMsg));
     } catch (error) {
       const reason =
         error instanceof Error ? error.message : 'Hubtel call failed';

--- a/backend/src/integrations/hubtel/public-payment.service.ts
+++ b/backend/src/integrations/hubtel/public-payment.service.ts
@@ -12,6 +12,7 @@ import {
   HubtelDirectReceiveService,
   InitiateReceiveMoneyResult,
 } from './hubtel-direct-receive.service';
+import { userFacingMessageForHubtelResponseCode } from './hubtel-response-codes';
 import { HubtelCredentialsService } from './hubtel-credentials.service';
 import {
   StudentInitiatePaymentDto,
@@ -215,7 +216,7 @@ export class PublicPaymentService {
           ? 'MoMo prompt sent. Approve on your phone.'
           : outcome.kind === 'paid'
             ? 'Payment processed successfully.'
-            : outcome.reason,
+            : userFacingMessageForHubtelResponseCode(outcome.responseCode),
       hubtelTransactionId,
     };
   }

--- a/backend/src/payments/dto/payment-query.dto.ts
+++ b/backend/src/payments/dto/payment-query.dto.ts
@@ -43,6 +43,11 @@ export class PaymentQueryDto {
 
   @ApiPropertyOptional()
   @IsOptional()
+  @IsString()
+  feeStructureId?: string;
+
+  @ApiPropertyOptional()
+  @IsOptional()
   @IsDateString()
   dateFrom?: string;
 

--- a/backend/src/payments/payment-config.ts
+++ b/backend/src/payments/payment-config.ts
@@ -1,0 +1,12 @@
+export type PaymentConfigStatus = 'ready' | 'paused' | 'not_onboarded';
+
+export const PAYMENT_CONFIG_STATUS = {
+  READY: 'ready',
+  PAUSED: 'paused',
+  NOT_ONBOARDED: 'not_onboarded',
+} as const satisfies Record<string, PaymentConfigStatus>;
+
+export interface SchoolPaymentConfig {
+  status: PaymentConfigStatus;
+  canInitiatePayment: boolean;
+}

--- a/backend/src/payments/payments.controller.ts
+++ b/backend/src/payments/payments.controller.ts
@@ -1,5 +1,5 @@
 import { Controller, Get, Param, Query, UseGuards } from '@nestjs/common';
-import { ApiTags } from '@nestjs/swagger';
+import { ApiOperation, ApiTags } from '@nestjs/swagger';
 import { PaymentsService } from './payments.service';
 import { PaymentQueryDto } from './dto/payment-query.dto';
 import { SchoolAdminJwtAuthGuard } from 'src/school-admin/guards/school-admin-jwt-auth.guard';
@@ -29,6 +29,14 @@ export class PaymentsController {
 
   @UseGuards(SchoolAdminJwtAuthGuard, ActiveUserGuard, RolesGuard)
   @Roles(Role.SchoolAdmin)
+  @Get('my-school/config')
+  @ApiOperation({ summary: 'Hubtel payment readiness for your school' })
+  getSchoolPaymentConfig(@CurrentUser() admin: SchoolAdmin) {
+    return this.paymentsService.getPaymentConfigForSchool(admin.school.id);
+  }
+
+  @UseGuards(SchoolAdminJwtAuthGuard, ActiveUserGuard, RolesGuard)
+  @Roles(Role.SchoolAdmin)
   @Get('my-school/:transactionId/receipt')
   getSchoolReceipt(
     @CurrentUser() admin: SchoolAdmin,
@@ -48,6 +56,14 @@ export class PaymentsController {
     @Query() query: PaymentQueryDto,
   ) {
     return this.paymentsService.listStudentPayments(student.id, query);
+  }
+
+  @UseGuards(StudentJwtAuthGuard, ActiveUserGuard, RolesGuard)
+  @Roles(Role.Student)
+  @Get('me/config')
+  @ApiOperation({ summary: 'Hubtel payment readiness for your school' })
+  getMyPaymentConfig(@CurrentUser() student: Student) {
+    return this.paymentsService.getPaymentConfigForSchool(student.school.id);
   }
 
   @UseGuards(StudentJwtAuthGuard, ActiveUserGuard, RolesGuard)

--- a/backend/src/payments/payments.module.ts
+++ b/backend/src/payments/payments.module.ts
@@ -9,6 +9,7 @@ import { PaymentAllocation } from './entities/payment-allocation.entity';
 import { CheckoutOtp } from './entities/checkout-otp.entity';
 import { Student } from 'src/student/student.entity';
 import { FeeStructure } from 'src/fee-structure/fee-structure.entity';
+import { School } from 'src/school/school.entity';
 
 @Module({
   imports: [
@@ -20,6 +21,7 @@ import { FeeStructure } from 'src/fee-structure/fee-structure.entity';
       CheckoutOtp,
       Student,
       FeeStructure,
+      School,
     ]),
   ],
   controllers: [PaymentsController],

--- a/backend/src/payments/payments.service.ts
+++ b/backend/src/payments/payments.service.ts
@@ -1085,7 +1085,7 @@ export class PaymentsService {
     if (!receipt) {
       throw new NotFoundException('Receipt not found');
     }
-    return receipt;
+    return this.ensureReceiptAllocations(receipt.id);
   }
 
   async getReceiptByTransactionForStudent(
@@ -1108,6 +1108,48 @@ export class PaymentsService {
     if (!receipt) {
       throw new NotFoundException('Receipt not found');
     }
+    return this.ensureReceiptAllocations(receipt.id);
+  }
+
+  private async ensureReceiptAllocations(
+    receiptId: string,
+  ): Promise<PaymentReceipt> {
+    let receipt = await this.paymentReceiptRepository.findOne({
+      where: { id: receiptId },
+      relations: [
+        'transaction',
+        'transaction.allocations',
+        'transaction.allocations.feeStructure',
+        'student',
+        'school',
+      ],
+    });
+
+    if (!receipt) {
+      throw new NotFoundException('Receipt not found');
+    }
+
+    const allocations = receipt.transaction.allocations ?? [];
+    if (
+      receipt.transaction.status === PaymentTransactionStatus.PAID &&
+      allocations.length === 0
+    ) {
+      await this.allocatePaidTransaction(receipt.transaction.id);
+      receipt = await this.paymentReceiptRepository.findOne({
+        where: { id: receiptId },
+        relations: [
+          'transaction',
+          'transaction.allocations',
+          'transaction.allocations.feeStructure',
+          'student',
+          'school',
+        ],
+      });
+      if (!receipt) {
+        throw new NotFoundException('Receipt not found');
+      }
+    }
+
     return receipt;
   }
 }

--- a/backend/src/payments/payments.service.ts
+++ b/backend/src/payments/payments.service.ts
@@ -6,11 +6,11 @@ import {
 } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import {
-  Between,
   Brackets,
+  In,
   LessThanOrEqual,
-  MoreThanOrEqual,
   Repository,
+  SelectQueryBuilder,
 } from 'typeorm';
 import { createHash, randomBytes, randomInt, randomUUID } from 'crypto';
 import {
@@ -27,9 +27,13 @@ import { FeeStructure } from 'src/fee-structure/fee-structure.entity';
 import { TransactionUtil } from 'src/common/utils/transaction.util';
 import { PaymentQueryDto } from './dto/payment-query.dto';
 import { HubtelMobileMoneyChannel } from 'src/integrations/hubtel/dto/initiate-receive-money.dto';
+import { School } from 'src/school/school.entity';
+import { PAYMENT_CONFIG_STATUS, SchoolPaymentConfig } from './payment-config';
 
 const OTP_TTL_MINUTES = 10;
 const OTP_MAX_ATTEMPTS = 5;
+const BILLING_CODE_PREFIX = 'SBC';
+const BILLING_CODE_DIGITS = 6;
 
 export interface CreateCheckoutOtpInput {
   student: Student;
@@ -52,6 +56,20 @@ export interface ConsumedCheckoutOtp {
   student: Student;
 }
 
+export interface SchoolPaymentsSummary {
+  totalTransactions: number;
+  paidCount: number;
+  pendingCount: number;
+  totalAmountGhs: number;
+}
+
+export interface StudentPaymentsSummary {
+  totalTransactions: number;
+  totalPaidAmountGhs: number;
+  pendingValueGhs: number;
+  pendingCount: number;
+}
+
 @Injectable()
 export class PaymentsService {
   private readonly logger = new Logger(PaymentsService.name);
@@ -69,10 +87,43 @@ export class PaymentsService {
     private readonly studentRepository: Repository<Student>,
     @InjectRepository(FeeStructure)
     private readonly feeStructureRepository: Repository<FeeStructure>,
+    @InjectRepository(School)
+    private readonly schoolRepository: Repository<School>,
     @InjectRepository(CheckoutOtp)
     private readonly checkoutOtpRepository: Repository<CheckoutOtp>,
     private readonly transactionUtil: TransactionUtil,
   ) {}
+
+  async getPaymentConfigForSchool(
+    schoolId: string,
+  ): Promise<SchoolPaymentConfig> {
+    const school = await this.schoolRepository.findOne({
+      where: { id: schoolId },
+    });
+    if (!school) {
+      throw new NotFoundException(`School with ID ${schoolId} not found`);
+    }
+
+    const configured = Boolean(
+      school.hubtelClientId &&
+        school.hubtelClientSecretEnc &&
+        school.hubtelCollectionAccountNumber,
+    );
+
+    let status: SchoolPaymentConfig['status'];
+    if (!configured) {
+      status = PAYMENT_CONFIG_STATUS.NOT_ONBOARDED;
+    } else if (!school.hubtelMerchantActive) {
+      status = PAYMENT_CONFIG_STATUS.PAUSED;
+    } else {
+      status = PAYMENT_CONFIG_STATUS.READY;
+    }
+
+    return {
+      status,
+      canInitiatePayment: status === PAYMENT_CONFIG_STATUS.READY,
+    };
+  }
 
   /**
    * Create a one-time-password tied to a specific payment intent
@@ -201,8 +252,11 @@ export class PaymentsService {
       throw new NotFoundException('Student not found');
     }
 
+    const normalizedInput = q.toUpperCase().replace(/\s+/g, '');
+    const billingCandidates = this.toBillingCodeCandidates(normalizedInput);
+
     let student = await this.studentRepository.findOne({
-      where: { studentBillingCode: q },
+      where: { studentBillingCode: In(billingCandidates) },
       relations: ['school', 'classLevels'],
     });
 
@@ -227,6 +281,36 @@ export class PaymentsService {
     }
 
     return student;
+  }
+
+  private toBillingCodeCandidates(normalizedInput: string): string[] {
+    const candidates = new Set<string>();
+    candidates.add(normalizedInput);
+
+    const digitsOnly = normalizedInput.replace(/\D/g, '');
+    if (digitsOnly && digitsOnly.length <= BILLING_CODE_DIGITS) {
+      candidates.add(digitsOnly.padStart(BILLING_CODE_DIGITS, '0'));
+      candidates.add(
+        `${BILLING_CODE_PREFIX}${digitsOnly.padStart(BILLING_CODE_DIGITS, '0')}`,
+      );
+    }
+
+    if (
+      normalizedInput.startsWith(BILLING_CODE_PREFIX) &&
+      normalizedInput.length > BILLING_CODE_PREFIX.length
+    ) {
+      const suffixDigits = normalizedInput
+        .slice(BILLING_CODE_PREFIX.length)
+        .replace(/\D/g, '');
+      if (suffixDigits && suffixDigits.length <= BILLING_CODE_DIGITS) {
+        candidates.add(suffixDigits.padStart(BILLING_CODE_DIGITS, '0'));
+        candidates.add(
+          `${BILLING_CODE_PREFIX}${suffixDigits.padStart(BILLING_CODE_DIGITS, '0')}`,
+        );
+      }
+    }
+
+    return Array.from(candidates);
   }
 
   /**
@@ -790,6 +874,8 @@ export class PaymentsService {
       qb.andWhere('payment.createdAt <= :dateTo', { dateTo: query.dateTo });
     }
 
+    const summary = await this.buildSchoolPaymentsSummary(qb);
+
     qb.orderBy('payment.createdAt', 'DESC')
       .skip((page - 1) * limit)
       .take(limit);
@@ -797,12 +883,36 @@ export class PaymentsService {
 
     return {
       data,
+      summary,
       meta: {
         total,
         page,
         limit,
         totalPages: Math.max(1, Math.ceil(total / limit)),
       },
+    };
+  }
+
+  private async buildSchoolPaymentsSummary(
+    qb: SelectQueryBuilder<PaymentTransaction>,
+  ): Promise<SchoolPaymentsSummary> {
+    const rows = await this.getDistinctPaymentRows(qb);
+    const paidRows = rows.filter(
+      (row) => row.status === PaymentTransactionStatus.PAID,
+    );
+    const pendingRows = rows.filter(
+      (row) => row.status === PaymentTransactionStatus.PENDING,
+    );
+    const totalAmountGhs = paidRows.reduce((sum, row) => {
+      const netAmount =
+        row.amountAfterCharges > 0 ? row.amountAfterCharges : row.amount;
+      return sum + netAmount;
+    }, 0);
+    return {
+      totalTransactions: rows.length,
+      paidCount: paidRows.length,
+      pendingCount: pendingRows.length,
+      totalAmountGhs: Math.round(totalAmountGhs * 100) / 100,
     };
   }
 
@@ -816,42 +926,67 @@ export class PaymentsService {
   ) {
     const page = query.page ?? 1;
     const limit = query.limit ?? 20;
-    const where: Record<string, unknown> = { student: { id: studentId } };
+    const qb = this.paymentTransactionRepository
+      .createQueryBuilder('payment')
+      .leftJoinAndSelect('payment.receipt', 'receipt')
+      .leftJoinAndSelect('payment.allocations', 'allocations')
+      .leftJoinAndSelect('allocations.feeStructure', 'feeStructure')
+      .leftJoinAndSelect('payment.student', 'student')
+      .where('student.id = :studentId', { studentId })
+      .distinct(true);
+
     if (query.status) {
-      where.status = query.status;
+      qb.andWhere('payment.status = :status', { status: query.status });
     }
-
-    let dateCondition: Date[] | undefined;
+    if (query.feeStructureId) {
+      qb.andWhere('feeStructure.id = :feeStructureId', {
+        feeStructureId: query.feeStructureId,
+      });
+    }
+    if (query.search) {
+      qb.andWhere(
+        new Brackets((builder) => {
+          builder
+            .where('payment.sessionId ILIKE :search', {
+              search: `%${query.search}%`,
+            })
+            .orWhere('payment.orderId ILIKE :search', {
+              search: `%${query.search}%`,
+            })
+            .orWhere('receipt.receiptNumber ILIKE :search', {
+              search: `%${query.search}%`,
+            })
+            .orWhere('feeStructure.feeTitle ILIKE :search', {
+              search: `%${query.search}%`,
+            });
+        }),
+      );
+    }
     if (query.dateFrom && query.dateTo) {
-      dateCondition = [new Date(query.dateFrom), new Date(query.dateTo)];
+      qb.andWhere('payment.createdAt BETWEEN :dateFrom AND :dateTo', {
+        dateFrom: query.dateFrom,
+        dateTo: query.dateTo,
+      });
+    } else if (query.dateFrom) {
+      qb.andWhere('payment.createdAt >= :dateFrom', {
+        dateFrom: query.dateFrom,
+      });
+    } else if (query.dateTo) {
+      qb.andWhere('payment.createdAt <= :dateTo', { dateTo: query.dateTo });
     }
 
-    const [data, total] = await this.paymentTransactionRepository.findAndCount({
-      where: {
-        ...where,
-        ...(dateCondition
-          ? { createdAt: Between(dateCondition[0], dateCondition[1]) }
-          : {}),
-        ...(query.dateFrom && !query.dateTo
-          ? { createdAt: MoreThanOrEqual(new Date(query.dateFrom)) }
-          : {}),
-        ...(query.dateTo && !query.dateFrom
-          ? { createdAt: LessThanOrEqual(new Date(query.dateTo)) }
-          : {}),
-      },
-      relations: [
-        'receipt',
-        'allocations',
-        'allocations.feeStructure',
-        'student',
-      ],
-      order: { createdAt: 'DESC' },
-      skip: (page - 1) * limit,
-      take: limit,
-    });
+    const summary = await this.buildStudentPaymentsSummary(qb);
+    const feeTypes = await this.buildStudentFeeTypeFilters(studentId);
+
+    qb.orderBy('payment.createdAt', 'DESC')
+      .skip((page - 1) * limit)
+      .take(limit);
+    const [data, total] = await qb.getManyAndCount();
 
     return {
       data,
+      summary,
+      filters: { feeTypes },
       meta: {
         total,
         page,
@@ -859,6 +994,75 @@ export class PaymentsService {
         totalPages: Math.max(1, Math.ceil(total / limit)),
       },
     };
+  }
+
+  private async buildStudentPaymentsSummary(
+    qb: SelectQueryBuilder<PaymentTransaction>,
+  ): Promise<StudentPaymentsSummary> {
+    const rows = await this.getDistinctPaymentRows(qb);
+    const paidRows = rows.filter(
+      (row) => row.status === PaymentTransactionStatus.PAID,
+    );
+    const pendingRows = rows.filter(
+      (row) => row.status === PaymentTransactionStatus.PENDING,
+    );
+    const totalPaidAmountGhs = paidRows.reduce((sum, row) => {
+      const netAmount =
+        row.amountAfterCharges > 0 ? row.amountAfterCharges : row.amount;
+      return sum + netAmount;
+    }, 0);
+    const pendingValueGhs = pendingRows.reduce((sum, row) => {
+      return sum + row.amount;
+    }, 0);
+    return {
+      totalTransactions: rows.length,
+      totalPaidAmountGhs: Math.round(totalPaidAmountGhs * 100) / 100,
+      pendingValueGhs: Math.round(pendingValueGhs * 100) / 100,
+      pendingCount: pendingRows.length,
+    };
+  }
+
+  private async buildStudentFeeTypeFilters(
+    studentId: string,
+  ): Promise<{ id: string; title: string }[]> {
+    const student = await this.getStudentById(studentId);
+    const feeStructures =
+      await this.findApplicableFeeStructuresForStudent(student);
+    return feeStructures.map((fee) => ({
+      id: fee.id,
+      title: (fee.feeTitle ?? 'Fee').trim() || 'Fee',
+    }));
+  }
+
+  private async getDistinctPaymentRows(
+    qb: SelectQueryBuilder<PaymentTransaction>,
+  ): Promise<
+    Array<{
+      id: string;
+      status: PaymentTransactionStatus;
+      amount: number;
+      amountAfterCharges: number;
+    }>
+  > {
+    const rows = await qb
+      .clone()
+      .select('payment.id', 'id')
+      .addSelect('payment.status', 'status')
+      .addSelect('payment.amount', 'amount')
+      .addSelect('payment.amountAfterCharges', 'amountAfterCharges')
+      .distinct(true)
+      .getRawMany<{
+        id: string;
+        status: PaymentTransactionStatus;
+        amount: number;
+        amountAfterCharges: number;
+      }>();
+    return rows.map((row) => ({
+      id: row.id,
+      status: row.status,
+      amount: Number(row.amount),
+      amountAfterCharges: Number(row.amountAfterCharges),
+    }));
   }
 
   async getReceiptByTransactionForSchoolAdmin(
@@ -869,7 +1073,13 @@ export class PaymentsService {
       where: {
         transaction: { id: transactionId, school: { id: schoolId } },
       },
-      relations: ['transaction', 'student', 'school'],
+      relations: [
+        'transaction',
+        'transaction.allocations',
+        'transaction.allocations.feeStructure',
+        'student',
+        'school',
+      ],
     });
 
     if (!receipt) {
@@ -886,7 +1096,13 @@ export class PaymentsService {
       where: {
         transaction: { id: transactionId, student: { id: studentId } },
       },
-      relations: ['transaction', 'student', 'school'],
+      relations: [
+        'transaction',
+        'transaction.allocations',
+        'transaction.allocations.feeStructure',
+        'student',
+        'school',
+      ],
     });
 
     if (!receipt) {

--- a/backend/src/payments/student-billing-code.backfill.ts
+++ b/backend/src/payments/student-billing-code.backfill.ts
@@ -2,13 +2,13 @@ import { INestApplication, Logger } from '@nestjs/common';
 import { getRepositoryToken } from '@nestjs/typeorm';
 import { IsNull, Repository } from 'typeorm';
 import { Student } from 'src/student/student.entity';
-import { randomBytes } from 'crypto';
+import { randomInt } from 'crypto';
 
 export async function seedStudentBillingCodes(app: INestApplication) {
   const logger = new Logger('StudentBillingCodeBackfill');
-  const studentRepository = app.get(
+  const studentRepository = app.get<Repository<Student>>(
     getRepositoryToken(Student),
-  ) as Repository<Student>;
+  );
 
   const students = await studentRepository.find({
     where: { studentBillingCode: IsNull() },
@@ -21,7 +21,8 @@ export async function seedStudentBillingCodes(app: INestApplication) {
 
   for (const student of students) {
     if (!student.studentBillingCode) {
-      student.studentBillingCode = await generateUniqueBillingCode(studentRepository);
+      student.studentBillingCode =
+        await generateUniqueBillingCode(studentRepository);
     }
   }
 
@@ -35,7 +36,7 @@ async function generateUniqueBillingCode(
   let code = '';
   let exists = true;
   while (exists) {
-    code = `SBC${randomBytes(4).toString('hex').toUpperCase()}`;
+    code = `SBC${String(randomInt(0, 1_000_000)).padStart(6, '0')}`;
     const student = await studentRepository.findOne({
       where: { studentBillingCode: code },
       select: ['id'],

--- a/frontend/src/@types/index.ts
+++ b/frontend/src/@types/index.ts
@@ -560,6 +560,13 @@ export interface SchoolPaymentsListParams {
   dateTo?: string;
 }
 
+export type PaymentConfigStatus = "ready" | "paused" | "not_onboarded";
+
+export interface SchoolPaymentConfig {
+  status: PaymentConfigStatus;
+  canInitiatePayment: boolean;
+}
+
 export interface HubtelMerchant {
   clientId: string | null;
   collectionAccountNumber: string | null;

--- a/frontend/src/components/admin/settings/SchoolSettingsTabSection.tsx
+++ b/frontend/src/components/admin/settings/SchoolSettingsTabSection.tsx
@@ -15,7 +15,7 @@ import {
   Select,
   Switch,
 } from "@mantine/core";
-import { useDeleteFeeStructure, useDeleteSchoolLogo, useEditFeeStructure, useGetFeeStructure, useSaveFeeStructure, useUpdateCalendlyUrl, useUploadSchoolLogoFile } from "@/hooks/school-admin";
+import { useDeleteFeeStructure, useDeleteSchoolLogo, useEditFeeStructure, useGetFeeStructure, useGetSchoolPaymentConfig, useSaveFeeStructure, useUpdateCalendlyUrl, useUploadSchoolLogoFile } from "@/hooks/school-admin";
 import { toast } from "react-toastify";
 import { ClassLevel, ErrorResponse, FeeStructure, School } from "@/@types";
 import { EmailItem } from "./EmailItem";
@@ -34,6 +34,10 @@ interface SchoolSettingsTabSectionProps {
 
 
 export const SchoolSettingsTabSection: React.FC<SchoolSettingsTabSectionProps> = ({schoolData, classes}) => {
+  const { config: paymentConfig } = useGetSchoolPaymentConfig();
+  const showUssdFeeSwitch =
+    paymentConfig != null && paymentConfig.status !== "not_onboarded";
+
   const [isFeeStructureDialogOpen, setIsFeeStructureDialogOpen] =
     useState(false);
   const [selectedDuration, setSelectedDuration] = useState<string>("daily");
@@ -157,7 +161,7 @@ export const SchoolSettingsTabSection: React.FC<SchoolSettingsTabSectionProps> =
      feeType: selectedDuration,
      amount: amount,
      dueDate: dueDate,
-     allowUssdPayment,
+     allowUssdPayment: showUssdFeeSwitch ? allowUssdPayment : true,
      classLevelIds: classLevelIdsForApi(),
     }, {
       onSuccess: () => {
@@ -186,7 +190,7 @@ export const SchoolSettingsTabSection: React.FC<SchoolSettingsTabSectionProps> =
      feeType: selectedDuration,
      amount: amount,
      dueDate: dueDate,
-     allowUssdPayment,
+     allowUssdPayment: showUssdFeeSwitch ? allowUssdPayment : true,
      classLevelIds: classLevelIdsForApi(),
     }, {
       onSuccess: () => {
@@ -511,12 +515,14 @@ export const SchoolSettingsTabSection: React.FC<SchoolSettingsTabSectionProps> =
             withCheckIcon
           />
 
-          <Switch
-            label="Payable via USSD"
-            description="If off, this fee will not be included in mobile or USSD payments."
-            checked={allowUssdPayment}
-            onChange={(e) => setAllowUssdPayment(e.currentTarget.checked)}
-          />
+          {showUssdFeeSwitch && (
+            <Switch
+              label="Payable via USSD"
+              description="If off, this fee will not be included in mobile or USSD payments."
+              checked={allowUssdPayment}
+              onChange={(e) => setAllowUssdPayment(e.currentTarget.checked)}
+            />
+          )}
 
           <NumberInput
             label="Amount"

--- a/frontend/src/hooks/school-admin.ts
+++ b/frontend/src/hooks/school-admin.ts
@@ -51,6 +51,7 @@ import {
   PaginatedSchoolPaymentsResponse,
   SchoolPaymentReceiptDetail,
   SchoolPaymentsListParams,
+  SchoolPaymentConfig,
   PostAttendancePayload,
 } from "@/@types";
 
@@ -2031,6 +2032,18 @@ export const useDeleteEventCategory = () => {
       queryClient.invalidateQueries({ queryKey: ["plannerEvents"] });
     },
   });
+};
+
+export const useGetSchoolPaymentConfig = () => {
+  const { data, isLoading, refetch } = useQuery({
+    queryKey: ["schoolPaymentConfig"],
+    queryFn: () => customAPI.get("/payments/my-school/config"),
+    refetchOnWindowFocus: true,
+  });
+
+  const config = data?.data as SchoolPaymentConfig | undefined;
+
+  return { config, isLoading, refetch };
 };
 
 export const useGetSchoolPayments = (params: SchoolPaymentsListParams) => {


### PR DESCRIPTION
- Add GET /payments/my-school/config and GET /payments/me/config returning
  { status, canInitiatePayment } derived from school Hubtel merchant fields.
- Register School on PaymentsModule; implement getPaymentConfigForSchool.
- Billing codes: SBC + 6-digit numeric; USSD resolves plain digits and prefixed form;
  align backfill/generation with numeric billing codes.
- School admin fee modal: hide "Payable via USSD" when school is not_onboarded;
  submit allowUssdPayment true when switch hidden.
- Hubtel: map response codes to short user-facing USSD/API messages; keep technical
  reasons for logs and failed transaction records. 
- resolves "Summary for the header cards: I need backend for them Paid and Pending, total amount are not showing for the header card"
- resolves "For a particular receipt, allocations array should be added"
- resolves "A list of the fees types for the students as filter"
- resolves"The total paid amount, pending value for the student"