### PR TITLE
fix: use a single EmailService instance on startup

### DIFF
--- a/backend/src/admission/admission.module.ts
+++ b/backend/src/admission/admission.module.ts
@@ -7,7 +7,6 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { Admission } from './admission.entity';
 import { School } from 'src/school/school.entity';
 import { ClassLevel } from 'src/class-level/class-level.entity';
-import { EmailService } from 'src/common/services/email.service';
 import { PreviousSchoolResult } from './previous-school-result.entity';
 import { Student } from 'src/student/student.entity';
 import { Profile } from 'src/profile/profile.entity';
@@ -36,11 +35,6 @@ import { Parent } from 'src/parent/parent.entity';
     ]),
   ],
   controllers: [AdmissionController],
-  providers: [
-    AdmissionService,
-    ObjectStorageServiceService,
-    EmailService,
-    InvitationService,
-  ],
+  providers: [AdmissionService, ObjectStorageServiceService, InvitationService],
 })
 export class AdmissionModule {}

--- a/backend/src/auth/auth.module.ts
+++ b/backend/src/auth/auth.module.ts
@@ -7,7 +7,6 @@ import { JwtModule } from '@nestjs/jwt';
 import { ConfigModule, ConfigService } from '@nestjs/config';
 import { Role } from 'src/role/role.entity';
 import { School } from 'src/school/school.entity';
-import { EmailService } from 'src/common/services/email.service';
 import { InvitationModule } from 'src/invitation/invitation.module';
 import { SchoolAdminModule } from '../school-admin/school-admin.module';
 import { SuperAdminModule } from '../super-admin/super-admin.module';
@@ -48,7 +47,7 @@ import { SuperAdmin } from '../super-admin/super-admin.entity';
     ConfigModule,
     InvitationModule,
   ],
-  providers: [AuthService, ConfigService, EmailService],
+  providers: [AuthService, ConfigService],
   controllers: [AuthController],
   exports: [AuthService],
 })

--- a/backend/src/common/modules/email.module.ts
+++ b/backend/src/common/modules/email.module.ts
@@ -1,8 +1,0 @@
-import { Module } from '@nestjs/common';
-import { EmailService } from '../services/email.service';
-
-@Module({
-  providers: [EmailService],
-  exports: [EmailService],
-})
-export class EmailModule {}

--- a/backend/src/common/services/email.service.ts
+++ b/backend/src/common/services/email.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, Logger, HttpStatus } from '@nestjs/common';
+import { Injectable, Logger, HttpStatus, OnModuleInit } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import * as nodemailer from 'nodemailer';
 import { EmailException } from '../exceptions/email.exception';
@@ -32,14 +32,14 @@ export enum EmailTemplate {
  * Email service for sending various types of emails
  */
 @Injectable()
-export class EmailService {
+export class EmailService implements OnModuleInit {
   private transporter: nodemailer.Transporter;
   private readonly logger = new Logger(EmailService.name);
   private readonly frontendUrl: string;
   private readonly fromEmail: string;
 
   constructor(private configService: ConfigService) {
-    this.initializeTransporter();
+    this.transporter = this.createTransporter();
     this.frontendUrl = this.configService.get<string>(
       'FRONTEND_URL',
       'http://localhost:3000',
@@ -50,23 +50,28 @@ export class EmailService {
     );
   }
 
-  private initializeTransporter(): void {
-    this.transporter = nodemailer.createTransport({
-      host: this.configService.get<string>('MAIL_HOST', 'smtp.example.com'),
-      port: this.configService.get<number>('MAIL_PORT', 587),
-      secure: this.configService.get<boolean>('MAIL_SECURE', false),
-      auth: {
-        user: this.configService.get<string>('MAIL_USER', ''),
-        pass: this.configService.get<string>('MAIL_PASSWORD', ''),
-      },
-    });
-
+  onModuleInit(): void {
     this.transporter.verify((error) => {
       if (error) {
         this.logger.error('Email service configuration error:', error);
       } else {
         this.logger.log('Email service is ready to send messages');
       }
+    });
+  }
+
+  private createTransporter(): nodemailer.Transporter {
+    const mailSecure = this.configService.get<string>('MAIL_SECURE', 'false');
+    const mailPort = Number(this.configService.get<string>('MAIL_PORT', '587'));
+
+    return nodemailer.createTransport({
+      host: this.configService.get<string>('MAIL_HOST', 'smtp.example.com'),
+      port: mailPort,
+      secure: mailSecure === 'true' || mailPort === 465,
+      auth: {
+        user: this.configService.get<string>('MAIL_USER', ''),
+        pass: this.configService.get<string>('MAIL_PASSWORD', ''),
+      },
     });
   }
 

--- a/backend/src/invitation/invitation.module.ts
+++ b/backend/src/invitation/invitation.module.ts
@@ -4,7 +4,6 @@ import { Role } from '../role/role.entity';
 import { School } from '../school/school.entity';
 import { InvitationService } from './invitation.service';
 import { InvitationController } from './invitation.controller';
-import { EmailModule } from '../common/modules/email.module';
 import { SchoolAdmin } from 'src/school-admin/school-admin.entity';
 import { StudentModule } from 'src/student/student.module';
 import { Student } from 'src/student/student.entity';
@@ -17,7 +16,6 @@ import { JwtModule } from '@nestjs/jwt';
 import { ConfigModule, ConfigService } from '@nestjs/config';
 import { PassportModule } from '@nestjs/passport';
 import { Teacher } from 'src/teacher/teacher.entity';
-import { EmailService } from 'src/common/services/email.service';
 import { TeacherService } from 'src/teacher/teacher.service';
 import { ObjectStorageServiceService } from 'src/object-storage-service/object-storage-service.service';
 import { AttendanceService } from 'src/attendance/attendance.service';
@@ -60,14 +58,12 @@ import { RefreshToken } from 'src/auth/entities/refresh-token.entity';
         signOptions: { expiresIn: '1d' },
       }),
     }),
-    EmailModule,
     StudentModule,
   ],
   providers: [
     InvitationService,
     TeacherService,
     SchoolAdminService,
-    EmailService,
     ObjectStorageServiceService,
     ProfileService,
     SchoolAdminAuthService,

--- a/backend/src/school-admin/school-admin.module.ts
+++ b/backend/src/school-admin/school-admin.module.ts
@@ -9,7 +9,6 @@ import { SchoolAdminAuthService } from './school-admin-auth.service';
 import { SchoolAdminService } from './school-admin.service';
 import { SchoolAdmin } from './school-admin.entity';
 import { School } from '../school/school.entity';
-import { EmailModule } from '../common/modules/email.module';
 import { SchoolAdminLocalStrategy } from './strategies/school-admin-local.strategy';
 import { SchoolAdminJwtStrategy } from './strategies/school-admin-jwt.strategy';
 import { AuthService } from 'src/auth/auth.service';
@@ -67,7 +66,6 @@ import { RefreshToken } from 'src/auth/entities/refresh-token.entity';
         signOptions: { expiresIn: '1d' },
       }),
     }),
-    EmailModule,
   ],
   controllers: [SchoolAdminController],
   providers: [

--- a/backend/src/student/student.module.ts
+++ b/backend/src/student/student.module.ts
@@ -4,7 +4,6 @@ import { StudentController } from './student.controller';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { Student } from './student.entity';
 import { Role } from '../role/role.entity';
-import { EmailModule } from '../common/modules/email.module';
 import { JwtModule } from '@nestjs/jwt';
 import { ConfigModule, ConfigService } from '@nestjs/config';
 import { StudentLocalStrategy } from './strategies/student-local.strategy';
@@ -14,7 +13,6 @@ import { AuthService } from 'src/auth/auth.service';
 import { StudentJwtStrategy } from './strategies/student-jwt.strategy';
 import { InvitationService } from 'src/invitation/invitation.service';
 import { School } from 'src/school/school.entity';
-import { EmailService } from 'src/common/services/email.service';
 import { SchoolAdmin } from 'src/school-admin/school-admin.entity';
 import { Teacher } from 'src/teacher/teacher.entity';
 import { Profile } from 'src/profile/profile.entity';
@@ -52,7 +50,6 @@ import { RefreshToken } from 'src/auth/entities/refresh-token.entity';
       Assignment,
       RefreshToken,
     ]),
-    EmailModule,
     JwtModule.registerAsync({
       imports: [ConfigModule],
       inject: [ConfigService],
@@ -68,7 +65,6 @@ import { RefreshToken } from 'src/auth/entities/refresh-token.entity';
   providers: [
     StudentService,
     AuthService,
-    EmailService,
     ProfileService,
     InvitationService,
     ObjectStorageServiceService,

--- a/backend/src/subject/subject.module.ts
+++ b/backend/src/subject/subject.module.ts
@@ -18,7 +18,6 @@ import { Holiday } from 'src/academic-calendar/entitites/holiday.entity';
 import { StudentTermRemark } from './student-term-remark.entity';
 import { TeacherService } from 'src/teacher/teacher.service';
 import { InvitationService } from 'src/invitation/invitation.service';
-import { EmailService } from 'src/common/services/email.service';
 import { ProfileService } from 'src/profile/profile.service';
 import { Role } from 'src/role/role.entity';
 import { SchoolAdmin } from 'src/school-admin/school-admin.entity';
@@ -55,7 +54,6 @@ import { Notification } from 'src/notification';
     AcademicCalendarService,
     TeacherService,
     InvitationService,
-    EmailService,
     ProfileService,
     NotificationService,
     ObjectStorageServiceService,

--- a/backend/src/teacher/teacher.module.ts
+++ b/backend/src/teacher/teacher.module.ts
@@ -12,10 +12,8 @@ import { TeacherJwtStrategy } from './strategies/teacher-jwt.strategy';
 import { TeacherJwtAuthGuard } from './guards/teacher-jwt-auth.guard';
 import { ConfigModule, ConfigService } from '@nestjs/config';
 import { JwtModule } from '@nestjs/jwt';
-import { EmailModule } from '../common/modules/email.module';
 import { InvitationService } from 'src/invitation/invitation.service';
 import { SchoolAdmin } from 'src/school-admin/school-admin.entity';
-import { EmailService } from 'src/common/services/email.service';
 import { Student } from 'src/student/student.entity';
 import { School } from 'src/school/school.entity';
 import { Profile } from 'src/profile/profile.entity';
@@ -60,7 +58,6 @@ import { CurriculumModule } from 'src/curriculum/curriculum.module';
       Subject,
       RefreshToken,
     ]),
-    EmailModule,
     JwtModule.registerAsync({
       imports: [ConfigModule],
       inject: [ConfigService],
@@ -75,7 +72,6 @@ import { CurriculumModule } from 'src/curriculum/curriculum.module';
   providers: [
     TeacherService,
     AuthService,
-    EmailService,
     ProfileService,
     ObjectStorageServiceService,
     TeacherAuthService,


### PR DESCRIPTION
Remove duplicate EmailService providers across feature modules so SMTP verify runs once instead of on every module instance. Move verificationnto onModuleInit and parse MAIL_PORT/MAIL_SECURE correctly from env vars.