### PR TITLE
feat: add aggregated-as-of cutoff to performance analytics

### DIFF
--- a/backend/src/student-analytics/student-analytics-admin.controller.ts
+++ b/backend/src/student-analytics/student-analytics-admin.controller.ts
@@ -36,7 +36,7 @@ export class StudentAnalyticsAdminController {
   @ApiOperation({
     summary: 'Get assignment-level performance analytics for a student',
     description:
-      "Returns subject → topic → assignment breakdown of a student's graded submission percentages for a given academic term.",
+      "Returns subject → topic → assignment breakdown of a student's graded submissions for a given academic term. Subject, topic, and overall averages use total points earned ÷ total points possible.",
   })
   @ApiParam({ name: 'studentId', description: 'UUID of the student' })
   @ApiQuery({
@@ -65,7 +65,7 @@ export class StudentAnalyticsAdminController {
   @ApiOperation({
     summary: 'Get per-topic performance breakdown for a student in a subject',
     description:
-      'Returns topic-level aggregated scores, class-wide average/range/median, test count, and performance cluster for a student in one subject for a given term. Clusters are derived from the school grading system bands. Used for the student detail page in Performance Breakdown.',
+      'Returns topic-level point-weighted aggregated scores (total earned ÷ total possible), class-wide average/range/median, test count, and performance cluster for a student in one subject for a given term. Clusters are derived from the school grading system bands. Used for the student detail page in Performance Breakdown.',
   })
   @ApiParam({ name: 'studentId', description: 'UUID of the student' })
   @ApiQuery({

--- a/backend/src/student-analytics/student-analytics-class.controller.ts
+++ b/backend/src/student-analytics/student-analytics-class.controller.ts
@@ -39,7 +39,7 @@ export class StudentAnalyticsClassController {
   @ApiOperation({
     summary: 'Get subject performance breakdown for all students in a class',
     description:
-      'Returns every student in the class with their aggregated assignment score, rank, and performance cluster for a given subject and term. Clusters are derived from the school grading system bands (not class rank). Also includes summary stats (average, median, highest, lowest) and cluster distribution counts. Supports optional filtering by cluster name and score range.',
+      'Returns every student in the class with their point-weighted aggregated assignment score (total earned ÷ total possible), rank, and performance cluster for a given subject and term. Only assignments graded on or before aggregatedAsOf (YYYY-MM-DD) are included when that query param is set. Clusters are derived from the school grading system bands (not class rank). Also includes summary stats (average, median, highest, lowest), aggregation metadata, and cluster distribution counts. Supports optional filtering by cluster name and score range.',
   })
   @ApiParam({ name: 'classLevelId', description: 'UUID of the class level' })
   @ApiQuery({
@@ -75,6 +75,13 @@ export class StudentAnalyticsClassController {
     required: false,
     type: Number,
   })
+  @ApiQuery({
+    name: 'aggregatedAsOf',
+    description:
+      'Inclusive cutoff date (YYYY-MM-DD). Only assignments graded on or before this date are included in term-to-date progress.',
+    required: false,
+    type: String,
+  })
   async getClassSubjectPerformance(
     @Param('classLevelId') classLevelId: string,
     @Query('academicTermId') academicTermId: string,
@@ -82,6 +89,7 @@ export class StudentAnalyticsClassController {
     @Query('cluster') cluster: string | undefined,
     @Query('scoreRangeMin') scoreRangeMin: string | undefined,
     @Query('scoreRangeMax') scoreRangeMax: string | undefined,
+    @Query('aggregatedAsOf') aggregatedAsOf: string | undefined,
     @CurrentUser() admin: SchoolAdmin,
   ) {
     if (!academicTermId?.trim()) {
@@ -119,6 +127,7 @@ export class StudentAnalyticsClassController {
           minFilter !== undefined && !isNaN(minFilter) ? minFilter : undefined,
         scoreRangeMax:
           maxFilter !== undefined && !isNaN(maxFilter) ? maxFilter : undefined,
+        aggregatedAsOf: aggregatedAsOf?.trim() || undefined,
       },
     );
   }

--- a/backend/src/student-analytics/student-analytics.service.ts
+++ b/backend/src/student-analytics/student-analytics.service.ts
@@ -1,4 +1,5 @@
 import {
+  BadRequestException,
   ForbiddenException,
   Injectable,
   NotFoundException,
@@ -25,6 +26,11 @@ export type ClassSubjectPerformanceResponse = {
   classLevel: { id: string; name: string };
   academicTerm: { id: string; termName: string };
   subject: { id: string; name: string };
+  aggregation: {
+    asOfDate: string;
+    latestGradedAt: string | null;
+    gradedAssignmentsCount: number;
+  };
   summary: {
     totalStudents: number;
     classAverage: number | null;
@@ -308,13 +314,14 @@ export class StudentAnalyticsService {
       catalogName: string;
       topicId: string;
       topicName: string;
-      percent: number;
       detail: TopicAssignmentGradeDetail;
     };
 
     let assignmentRows: Row[] = filteredSubs.map((sub) => {
-      const pct = (Number(sub.score) / Number(sub.assignment.maxScore)) * 100;
-      const roundedPct = Math.round(Math.min(100, Math.max(0, pct)) * 10) / 10;
+      const roundedPct = this.submissionPercent(
+        Number(sub.score),
+        Number(sub.assignment.maxScore),
+      );
       const due = sub.assignment.dueDate;
       const dueDateIso =
         due instanceof Date ? due.toISOString() : new Date(due).toISOString();
@@ -337,7 +344,6 @@ export class StudentAnalyticsService {
         catalogName: sub.assignment.topic.subjectCatalog.name,
         topicId: sub.assignment.topic.id,
         topicName: sub.assignment.topic.name,
-        percent: roundedPct,
         detail,
       };
     });
@@ -348,25 +354,25 @@ export class StudentAnalyticsService {
     }
 
     const gradedAssignmentsCount = assignmentRows.length;
-    const assignmentAvg =
-      gradedAssignmentsCount > 0
-        ? Math.round(
-            (assignmentRows.reduce((a, r) => a + r.percent, 0) /
-              gradedAssignmentsCount) *
-              10,
-          ) / 10
-        : null;
+    const assignmentAvg = this.weightedAveragePercent(
+      assignmentRows.map((r) => ({
+        score: r.detail.score,
+        maxScore: r.detail.maxScore,
+      })),
+    );
+
+    type ScoreMaxPair = { score: number; maxScore: number };
 
     const bySubject = new Map<
       string,
       {
         subjectName: string;
-        percents: number[];
+        scorePairs: ScoreMaxPair[];
         topics: Map<
           string,
           {
             topicName: string;
-            percents: number[];
+            scorePairs: ScoreMaxPair[];
             assignments: TopicAssignmentGradeDetail[];
           }
         >;
@@ -374,39 +380,33 @@ export class StudentAnalyticsService {
     >();
 
     for (const row of assignmentRows) {
+      const pair = { score: row.detail.score, maxScore: row.detail.maxScore };
       let subj = bySubject.get(row.catalogId);
       if (!subj) {
         subj = {
           subjectName: row.catalogName,
-          percents: [],
+          scorePairs: [],
           topics: new Map(),
         };
         bySubject.set(row.catalogId, subj);
       }
-      subj.percents.push(row.percent);
+      subj.scorePairs.push(pair);
       let top = subj.topics.get(row.topicId);
       if (!top) {
         top = {
           topicName: row.topicName,
-          percents: [],
+          scorePairs: [],
           assignments: [],
         };
         subj.topics.set(row.topicId, top);
       }
-      top.percents.push(row.percent);
+      top.scorePairs.push(pair);
       top.assignments.push(row.detail);
     }
 
     const subjectAssignmentPerformance: PerformanceAnalyticsResponse['subjectAssignmentPerformance'] =
       [...bySubject.entries()].map(([subjectCatalogId, data]) => {
-        const avg =
-          data.percents.length > 0
-            ? Math.round(
-                (data.percents.reduce((a, b) => a + b, 0) /
-                  data.percents.length) *
-                  10,
-              ) / 10
-            : null;
+        const avg = this.weightedAveragePercent(data.scorePairs);
         const topics = [...data.topics.entries()].map(([topicId, t]) => {
           const assignments = [...t.assignments].sort((x, y) =>
             y.dueDate.localeCompare(x.dueDate),
@@ -414,15 +414,8 @@ export class StudentAnalyticsService {
           return {
             topicId,
             topicName: t.topicName,
-            gradedCount: t.percents.length,
-            averagePercent:
-              t.percents.length > 0
-                ? Math.round(
-                    (t.percents.reduce((a, b) => a + b, 0) /
-                      t.percents.length) *
-                      10,
-                  ) / 10
-                : null,
+            gradedCount: t.scorePairs.length,
+            averagePercent: this.weightedAveragePercent(t.scorePairs),
             assignments,
           };
         });
@@ -430,7 +423,7 @@ export class StudentAnalyticsService {
         return {
           subjectCatalogId,
           subjectName: data.subjectName,
-          gradedCount: data.percents.length,
+          gradedCount: data.scorePairs.length,
           averagePercent: avg,
           topics,
         };
@@ -456,29 +449,65 @@ export class StudentAnalyticsService {
 
   // ─── Cluster / stats helpers ────────────────────────────────────────────────
 
-  private round1(n: number): number {
-    return Math.round(n * 10) / 10;
+  private roundPercent(n: number): number {
+    return Math.round(n);
+  }
+
+  /** End of calendar day UTC for YYYY-MM-DD (inclusive graded-through date). */
+  private parseAggregatedAsOfDate(isoDate: string): string | null {
+    const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(isoDate.trim());
+    if (!match) return null;
+    const year = Number(match[1]);
+    const month = Number(match[2]);
+    const day = Number(match[3]);
+    const probe = new Date(Date.UTC(year, month - 1, day));
+    if (
+      probe.getUTCFullYear() !== year ||
+      probe.getUTCMonth() !== month - 1 ||
+      probe.getUTCDate() !== day
+    ) {
+      return null;
+    }
+    return `${match[1]}-${match[2]}-${match[3]}`;
+  }
+
+  private gradedDateKey(sub: AssignmentSubmission): string {
+    const d = this.submissionGradedAt(sub);
+    const y = d.getUTCFullYear();
+    const m = String(d.getUTCMonth() + 1).padStart(2, '0');
+    const day = String(d.getUTCDate()).padStart(2, '0');
+    return `${y}-${m}-${day}`;
+  }
+
+  private submissionGradedAt(sub: AssignmentSubmission): Date {
+    return sub.updatedAt instanceof Date
+      ? sub.updatedAt
+      : new Date(sub.updatedAt);
   }
 
   private computeMedian(sortedAsc: number[]): number | null {
     if (!sortedAsc.length) return null;
     const mid = Math.floor(sortedAsc.length / 2);
     return sortedAsc.length % 2 === 0
-      ? this.round1((sortedAsc[mid - 1] + sortedAsc[mid]) / 2)
+      ? this.roundPercent((sortedAsc[mid - 1] + sortedAsc[mid]) / 2)
       : sortedAsc[mid];
   }
 
   private submissionPercent(score: number, maxScore: number): number {
-    return this.round1(
+    return this.roundPercent(
       Math.min(100, Math.max(0, (Number(score) / Number(maxScore)) * 100)),
     );
   }
 
-  private averageSubmissionPercents(percents: number[]): number | null {
-    if (!percents.length) return null;
-    return this.round1(
-      percents.reduce((a, b) => a + b, 0) / percents.length,
-    );
+  /** Total earned ÷ total possible, as a percentage (point-weighted average). */
+  private weightedAveragePercent(
+    items: Array<{ score: number; maxScore: number }>,
+  ): number | null {
+    if (!items.length) return null;
+    const totalScore = items.reduce((sum, i) => sum + Number(i.score), 0);
+    const totalMax = items.reduce((sum, i) => sum + Number(i.maxScore), 0);
+    if (totalMax <= 0) return null;
+    return this.roundPercent((totalScore / totalMax) * 100);
   }
 
   private async loadGradingBands(schoolId: string): Promise<GradingSystem[]> {
@@ -562,6 +591,7 @@ export class StudentAnalyticsService {
       cluster?: ClusterName;
       scoreRangeMin?: number;
       scoreRangeMax?: number;
+      aggregatedAsOf?: string;
     } = {},
   ): Promise<ClassSubjectPerformanceResponse> {
     const classLevel = await this.classLevelRepository.findOne({
@@ -604,15 +634,39 @@ export class StudentAnalyticsService {
       (sub) => sub.assignment.topic.academicTerm?.id === academicTermId,
     );
 
-    // Aggregate per-student average
-    const studentScoreMap = new Map<string, number[]>();
-    for (const sub of termSubs) {
-      const pct = this.submissionPercent(
-        Number(sub.score),
-        Number(sub.assignment.maxScore),
+    const asOfDateKey = filters.aggregatedAsOf
+      ? this.parseAggregatedAsOfDate(filters.aggregatedAsOf)
+      : null;
+    if (filters.aggregatedAsOf && !asOfDateKey) {
+      throw new BadRequestException(
+        'aggregatedAsOf must be a valid date (YYYY-MM-DD)',
       );
+    }
+
+    const includedSubs = asOfDateKey
+      ? termSubs.filter((sub) => this.gradedDateKey(sub) <= asOfDateKey)
+      : termSubs;
+
+    let latestGradedAt: string | null = null;
+    for (const sub of includedSubs) {
+      const gradedAt = this.submissionGradedAt(sub).toISOString();
+      if (!latestGradedAt || gradedAt > latestGradedAt) {
+        latestGradedAt = gradedAt;
+      }
+    }
+
+    // Aggregate per-student point-weighted average
+    const studentScoreMap = new Map<
+      string,
+      Array<{ score: number; maxScore: number }>
+    >();
+    for (const sub of includedSubs) {
+      const pair = {
+        score: Number(sub.score),
+        maxScore: Number(sub.assignment.maxScore),
+      };
       const arr = studentScoreMap.get(sub.student.id) ?? [];
-      arr.push(pct);
+      arr.push(pair);
       studentScoreMap.set(sub.student.id, arr);
     }
 
@@ -623,8 +677,8 @@ export class StudentAnalyticsService {
     };
 
     const allEntries: Entry[] = classLevel.students.map((s) => {
-      const scores = studentScoreMap.get(s.id);
-      const avg = this.averageSubmissionPercents(scores ?? []);
+      const scorePairs = studentScoreMap.get(s.id);
+      const avg = this.weightedAveragePercent(scorePairs ?? []);
       return {
         studentId: s.id,
         studentName: `${s.firstName ?? ''} ${s.lastName ?? ''}`.trim(),
@@ -658,7 +712,7 @@ export class StudentAnalyticsService {
       .map((e) => e.avgScore!)
       .sort((a, b) => a - b);
     const classAverage = sortedScores.length
-      ? this.round1(
+      ? this.roundPercent(
           sortedScores.reduce((a, b) => a + b, 0) / sortedScores.length,
         )
       : null;
@@ -704,6 +758,11 @@ export class StudentAnalyticsService {
       classLevel: { id: classLevel.id, name: classLevel.name },
       academicTerm: { id: termEntity.id, termName: termEntity.termName },
       subject: { id: subjectCatalogId, name: subjectName },
+      aggregation: {
+        asOfDate: asOfDateKey ?? '',
+        latestGradedAt,
+        gradedAssignmentsCount: includedSubs.length,
+      },
       summary: {
         totalStudents: classLevel.students.length,
         classAverage,
@@ -801,7 +860,7 @@ export class StudentAnalyticsService {
     type TopicAccum = {
       topicName: string;
       assignmentIds: Set<string>;
-      perStudentScores: Map<string, number[]>;
+      perStudentScores: Map<string, Array<{ score: number; maxScore: number }>>;
     };
 
     const topicMap = new Map<string, TopicAccum>();
@@ -818,31 +877,32 @@ export class StudentAnalyticsService {
         topicMap.set(topicId, td);
       }
       td.assignmentIds.add(sub.assignment.id);
-      const pct = this.submissionPercent(
-        Number(sub.score),
-        Number(sub.assignment.maxScore),
-      );
+      const pair = {
+        score: Number(sub.score),
+        maxScore: Number(sub.assignment.maxScore),
+      };
       const arr = td.perStudentScores.get(sub.student.id) ?? [];
-      arr.push(pct);
+      arr.push(pair);
       td.perStudentScores.set(sub.student.id, arr);
     }
 
     const topics: StudentTopicPerformanceResponse['topics'] = [];
 
     for (const [topicId, td] of topicMap) {
-      // Per-student averages for this topic
+      // Per-student point-weighted averages for this topic
       const studentTopicAvgs: number[] = [];
       let thisStudentAvg: number | null = null;
 
-      for (const [sid, scores] of td.perStudentScores) {
-        const avg = this.averageSubmissionPercents(scores)!;
+      for (const [sid, scorePairs] of td.perStudentScores) {
+        const avg = this.weightedAveragePercent(scorePairs);
+        if (avg === null) continue;
         studentTopicAvgs.push(avg);
         if (sid === studentId) thisStudentAvg = avg;
       }
 
       const sorted = [...studentTopicAvgs].sort((a, b) => a - b);
       const classAverage = sorted.length
-        ? this.round1(sorted.reduce((a, b) => a + b, 0) / sorted.length)
+        ? this.roundPercent(sorted.reduce((a, b) => a + b, 0) / sorted.length)
         : null;
       const median = this.computeMedian(sorted);
       const range = sorted.length
@@ -869,10 +929,12 @@ export class StudentAnalyticsService {
     topics.sort((a, b) => a.topicName.localeCompare(b.topicName));
 
     const studentSubs = termSubs.filter((s) => s.student.id === studentId);
-    const overallPercents = studentSubs.map((s) =>
-      this.submissionPercent(Number(s.score), Number(s.assignment.maxScore)),
+    const overallAvg = this.weightedAveragePercent(
+      studentSubs.map((s) => ({
+        score: Number(s.score),
+        maxScore: Number(s.assignment.maxScore),
+      })),
     );
-    const overallAvg = this.averageSubmissionPercents(overallPercents);
     const overallCluster =
       overallAvg !== null
         ? this.assignClusterByScore(overallAvg, gradingBands)

--- a/frontend/src/@types/index.ts
+++ b/frontend/src/@types/index.ts
@@ -852,6 +852,11 @@ export interface ClassSubjectPerformanceResponse {
   classLevel: { id: string; name: string };
   academicTerm: { id: string; termName: string };
   subject: { id: string; name: string };
+  aggregation: {
+    asOfDate: string;
+    latestGradedAt: string | null;
+    gradedAssignmentsCount: number;
+  };
   summary: {
     totalStudents: number;
     classAverage: number | null;

--- a/frontend/src/app/admin/performance-analytics/[studentId]/page.tsx
+++ b/frontend/src/app/admin/performance-analytics/[studentId]/page.tsx
@@ -16,19 +16,16 @@ import {
   CLUSTER_STYLES,
   initialsFromName,
 } from "@/components/admin/performance/performanceClusters";
+import {
+  formatPercent,
+  formatPercentRange,
+  roundPercent,
+} from "@/utils/formatPercent";
 
 const headerCell =
   "px-6 py-3.5 text-xs font-medium uppercase tracking-wide text-gray-500 whitespace-nowrap border-b border-solid border-b-[#EAECF0] text-left max-md:px-5";
 const bodyCell =
   "px-6 py-4 border-b border-solid border-b-[#EAECF0] whitespace-nowrap max-md:px-5";
-
-const fmtPercent = (value: number | null | undefined) =>
-  value === null || value === undefined ? "—" : `${Math.round(value)}%`;
-
-const formatRange = (min: number | null, max: number | null) => {
-  if (min === null || max === null) return "—";
-  return `${Math.round(min)}%–${Math.round(max)}%`;
-};
 
 function sanitizeReturnPath(raw: string | null): string | null {
   if (!raw || !raw.startsWith("/admin/performance-analytics")) return null;
@@ -156,14 +153,14 @@ const StudentPerformanceDetailPage = () => {
               </p>
               <div className="mt-2 flex items-center gap-3">
                 <Progress
-                  value={student.overallAveragePercent ?? 0}
+                  value={roundPercent(student.overallAveragePercent ?? 0)}
                   color={overallProgressColor}
                   radius="xl"
                   size="md"
                   className="flex-1"
                 />
                 <span className="text-lg font-bold text-neutral-800 tabular-nums w-14 text-right">
-                  {fmtPercent(student.overallAveragePercent)}
+                  {formatPercent(student.overallAveragePercent)}
                 </span>
               </div>
             </div>
@@ -214,22 +211,22 @@ const StudentPerformanceDetailPage = () => {
                         <td
                           className={`${bodyCell} text-sm font-semibold text-zinc-900 tabular-nums`}
                         >
-                          {fmtPercent(topic.studentAggregatedScore)}
+                          {formatPercent(topic.studentAggregatedScore)}
                         </td>
                         <td
                           className={`${bodyCell} text-sm text-zinc-600 tabular-nums`}
                         >
-                          {fmtPercent(topic.classAverage)}
+                          {formatPercent(topic.classAverage)}
                         </td>
                         <td
                           className={`${bodyCell} text-sm text-zinc-600 tabular-nums`}
                         >
-                          {formatRange(topic.range.min, topic.range.max)}
+                          {formatPercentRange(topic.range.min, topic.range.max)}
                         </td>
                         <td
                           className={`${bodyCell} text-sm text-zinc-600 tabular-nums`}
                         >
-                          {fmtPercent(topic.median)}
+                          {formatPercent(topic.median)}
                         </td>
                         <td
                           className={`${bodyCell} text-sm text-zinc-600 tabular-nums`}

--- a/frontend/src/app/admin/performance-analytics/page.tsx
+++ b/frontend/src/app/admin/performance-analytics/page.tsx
@@ -2,9 +2,10 @@
 
 import React, { useCallback, useEffect, useMemo, useState } from "react";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
-import { Badge, Combobox, Select } from "@mantine/core";
+import { Badge, Combobox, Select, TextInput } from "@mantine/core";
 import {
   IconActivity,
+  IconCalendar,
   IconDownload,
   IconFilter,
   IconTrendingDown,
@@ -12,6 +13,7 @@ import {
   IconTrophy,
   IconUsers,
 } from "@tabler/icons-react";
+import dayjs from "dayjs";
 import { HashLoader } from "react-spinners";
 import { toast } from "react-toastify";
 
@@ -22,7 +24,9 @@ import {
   useGetClassSubjectPerformance,
 } from "@/hooks/school-admin";
 import { getSortedSchoolTerms } from "@/utils/schoolTerms";
+import { formatPercent, roundPercent } from "@/utils/formatPercent";
 import NoAvailableEmptyState from "@/components/common/NoAvailableEmptyState";
+import { Pagination } from "@/components/common/Pagination";
 import PerformanceBreakdownTable from "@/components/admin/performance/PerformanceBreakdownTable";
 import ScoreDistributionChart from "@/components/admin/performance/ScoreDistributionChart";
 import {
@@ -81,12 +85,34 @@ const filterIcon = (
   <IconFilter size={16} className="text-zinc-400" aria-hidden />
 );
 
+/** Match Select filter styling from mantineTheme.ts */
+const filterFieldClassNames = {
+  label: "!text-xs !text-zinc-600 !font-normal mb-0",
+  input:
+    "!py-4 !border-solid !border-[0.5px] !border-zinc-500 text-zinc-800",
+} as const;
+
+const PERFORMANCE_STUDENTS_PAGE_SIZE = 10;
+
+function getTodayDateInputValue(): string {
+  return dayjs().format("YYYY-MM-DD");
+}
+
+function isValidDateInput(value: string): boolean {
+  return dayjs(value, "YYYY-MM-DD", true).isValid();
+}
+
+function formatAggregatedAsOfLabel(dateInput: string): string {
+  return dayjs(dateInput).format("D MMM YYYY");
+}
+
 const PA = {
   classLevel: "classLevelId",
   term: "academicTermId",
   subject: "subjectCatalogId",
   cluster: "cluster",
   scoreRange: "scoreRange",
+  aggregatedAsOf: "aggregatedAsOf",
 } as const;
 
 type PerformanceFilters = {
@@ -95,6 +121,7 @@ type PerformanceFilters = {
   selectedSubjectId: string | null;
   selectedCluster: string;
   selectedScoreRange: string;
+  aggregatedAsOf: string;
 };
 
 function buildFilterSearchParams(filters: PerformanceFilters): URLSearchParams {
@@ -104,6 +131,7 @@ function buildFilterSearchParams(filters: PerformanceFilters): URLSearchParams {
   if (filters.selectedSubjectId) p.set(PA.subject, filters.selectedSubjectId);
   if (filters.selectedCluster) p.set(PA.cluster, filters.selectedCluster);
   if (filters.selectedScoreRange) p.set(PA.scoreRange, filters.selectedScoreRange);
+  if (filters.aggregatedAsOf) p.set(PA.aggregatedAsOf, filters.aggregatedAsOf);
   return p;
 }
 
@@ -116,7 +144,9 @@ function filtersMatchUrl(
     (searchParams.get(PA.term) ?? "") === (filters.selectedTermId ?? "") &&
     (searchParams.get(PA.subject) ?? "") === (filters.selectedSubjectId ?? "") &&
     (searchParams.get(PA.cluster) ?? "") === filters.selectedCluster &&
-    (searchParams.get(PA.scoreRange) ?? "") === filters.selectedScoreRange
+    (searchParams.get(PA.scoreRange) ?? "") === filters.selectedScoreRange &&
+    (searchParams.get(PA.aggregatedAsOf) ?? getTodayDateInputValue()) ===
+      filters.aggregatedAsOf
   );
 }
 
@@ -140,6 +170,13 @@ const PerformanceAnalyticsPage = () => {
   const [selectedScoreRange, setSelectedScoreRange] = useState<string>(
     () => searchParams.get(PA.scoreRange) ?? ""
   );
+  const [aggregatedAsOf, setAggregatedAsOf] = useState<string>(() => {
+    const fromUrl = searchParams.get(PA.aggregatedAsOf) ?? "";
+    return fromUrl && isValidDateInput(fromUrl)
+      ? fromUrl
+      : getTodayDateInputValue();
+  });
+  const [currentPage, setCurrentPage] = useState(1);
 
   const { classLevels } = useGetClassLevels("");
   const { subjects } = useGetAllSubjects();
@@ -158,6 +195,7 @@ const PerformanceAnalyticsPage = () => {
       selectedSubjectId,
       selectedCluster,
       selectedScoreRange,
+      aggregatedAsOf,
     }),
     [
       selectedClassId,
@@ -165,6 +203,7 @@ const PerformanceAnalyticsPage = () => {
       selectedSubjectId,
       selectedCluster,
       selectedScoreRange,
+      aggregatedAsOf,
     ]
   );
 
@@ -190,7 +229,9 @@ const PerformanceAnalyticsPage = () => {
         setSelectedCluster(partial.selectedCluster);
       if (partial.selectedScoreRange !== undefined)
         setSelectedScoreRange(partial.selectedScoreRange);
-      
+      if (partial.aggregatedAsOf !== undefined)
+        setAggregatedAsOf(partial.aggregatedAsOf);
+
       replaceFiltersUrl(next);
     },
     [currentFilters, replaceFiltersUrl]
@@ -202,6 +243,10 @@ const PerformanceAnalyticsPage = () => {
     setSelectedSubjectId(searchParams.get(PA.subject) || null);
     setSelectedCluster(searchParams.get(PA.cluster) ?? "");
     setSelectedScoreRange(searchParams.get(PA.scoreRange) ?? "");
+    const urlAsOf = searchParams.get(PA.aggregatedAsOf) ?? "";
+    setAggregatedAsOf(
+      urlAsOf && isValidDateInput(urlAsOf) ? urlAsOf : getTodayDateInputValue()
+    );
   }, [searchParams]);
 
   const buildOverviewUrl = useCallback(() => {
@@ -292,6 +337,16 @@ const PerformanceAnalyticsPage = () => {
     replaceFiltersUrl(next);
   }, [subjectOptions]);
 
+  // Default aggregated-as-of to today when URL has no valid date.
+  useEffect(() => {
+    const urlAsOf = searchParams.get(PA.aggregatedAsOf) ?? "";
+    const nextAsOf =
+      urlAsOf && isValidDateInput(urlAsOf) ? urlAsOf : getTodayDateInputValue();
+    const next = { ...currentFilters, aggregatedAsOf: nextAsOf };
+    if (nextAsOf !== aggregatedAsOf) setAggregatedAsOf(nextAsOf);
+    replaceFiltersUrl(next);
+  }, [searchParams]);
+
   const termSelectData = useMemo(
     () =>
       sortedTerms.map((t) => {
@@ -344,6 +399,7 @@ const PerformanceAnalyticsPage = () => {
       cluster: (selectedCluster || undefined) as PerformanceCluster | undefined,
       scoreRangeMin: scoreRange?.min,
       scoreRangeMax: scoreRange?.max,
+      aggregatedAsOf,
     },
     { enabled: filtersReady }
   );
@@ -352,8 +408,42 @@ const PerformanceAnalyticsPage = () => {
   const distribution = performance?.clusterDistribution;
   const students = performance?.students ?? [];
 
-  const fmtPercent = (value: number | null | undefined) =>
-    value === null || value === undefined ? "—" : `${Math.round(value)}%`;
+  useEffect(() => {
+    setCurrentPage(1);
+  }, [
+    selectedClassId,
+    selectedTermId,
+    selectedSubjectId,
+    selectedCluster,
+    selectedScoreRange,
+    aggregatedAsOf,
+  ]);
+
+  const totalStudentPages = Math.max(
+    1,
+    Math.ceil(students.length / PERFORMANCE_STUDENTS_PAGE_SIZE),
+  );
+
+  useEffect(() => {
+    if (currentPage > totalStudentPages) {
+      setCurrentPage(totalStudentPages);
+    }
+  }, [currentPage, totalStudentPages]);
+
+  const paginatedStudents = useMemo(() => {
+    const start = (currentPage - 1) * PERFORMANCE_STUDENTS_PAGE_SIZE;
+    return students.slice(start, start + PERFORMANCE_STUDENTS_PAGE_SIZE);
+  }, [students, currentPage]);
+
+  const studentRangeLabel = useMemo(() => {
+    if (students.length === 0) return null;
+    const start = (currentPage - 1) * PERFORMANCE_STUDENTS_PAGE_SIZE + 1;
+    const end = Math.min(
+      currentPage * PERFORMANCE_STUDENTS_PAGE_SIZE,
+      students.length,
+    );
+    return `Showing ${start}–${end} of ${students.length} students`;
+  }, [students.length, currentPage]);
 
   const handleExportCsv = () => {
     if (!performance || students.length === 0) {
@@ -375,7 +465,9 @@ const PerformanceAnalyticsPage = () => {
         s.studentName,
         s.classLevelName,
         s.subjectName,
-        s.aggregatedScore === null ? "" : String(s.aggregatedScore),
+        s.aggregatedScore === null
+          ? ""
+          : String(roundPercent(s.aggregatedScore)),
         s.cluster ?? "",
       ]
         .map(escape)
@@ -437,25 +529,25 @@ const PerformanceAnalyticsPage = () => {
           />
           <StatCard
             title="Class Average"
-            value={fmtPercent(summary?.classAverage)}
+            value={formatPercent(summary?.classAverage)}
             accent="cyan"
             icon={<IconTrendingUp size={22} stroke={1.75} />}
           />
           <StatCard
             title="Median Score"
-            value={fmtPercent(summary?.medianScore)}
+            value={formatPercent(summary?.medianScore)}
             accent="indigo"
             icon={<IconActivity size={22} stroke={1.75} />}
           />
           <StatCard
             title="Highest Score"
-            value={fmtPercent(summary?.highestScore)}
+            value={formatPercent(summary?.highestScore)}
             accent="emerald"
             icon={<IconTrophy size={22} stroke={1.75} />}
           />
           <StatCard
             title="Lowest Score"
-            value={fmtPercent(summary?.lowestScore)}
+            value={formatPercent(summary?.lowestScore)}
             accent="rose"
             icon={<IconTrendingDown size={22} stroke={1.75} />}
           />
@@ -492,7 +584,7 @@ const PerformanceAnalyticsPage = () => {
           </p>
           <div className="mt-4">
             <ScoreDistributionChart
-              key={`${selectedClassId}-${selectedTermId}-${selectedSubjectId}-${selectedCluster}-${selectedScoreRange}`}
+              key={`${selectedClassId}-${selectedTermId}-${selectedSubjectId}-${selectedCluster}-${selectedScoreRange}-${aggregatedAsOf}`}
               students={students}
               median={summary?.medianScore ?? null}
               classAverage={summary?.classAverage ?? null}
@@ -501,23 +593,35 @@ const PerformanceAnalyticsPage = () => {
         </div>
 
           {/* Ranked breakdown table */}
-          <PerformanceBreakdownTable
-            students={students}
-            isLoading={isFetching && !isLoading}
-            onRowAction={(studentId) => {
-              const params = new URLSearchParams();
-              if (selectedTermId){
-                params.set("academicTermId", selectedTermId);
-              }
-              if (selectedSubjectId){
-                params.set("subjectCatalogId", selectedSubjectId);
-              }
-              params.set("returnPath", buildOverviewUrl());
-              router.push(
-                `/admin/performance-analytics/${studentId}?${params.toString()}`
-              );
-            }}
-          />
+          <div className="flex flex-col gap-1">
+            {studentRangeLabel ? (
+              <p className="text-xs text-zinc-500 px-1">{studentRangeLabel}</p>
+            ) : null}
+            <PerformanceBreakdownTable
+              students={paginatedStudents}
+              isLoading={isFetching && !isLoading}
+              onRowAction={(studentId) => {
+                const params = new URLSearchParams();
+                if (selectedTermId) {
+                  params.set("academicTermId", selectedTermId);
+                }
+                if (selectedSubjectId) {
+                  params.set("subjectCatalogId", selectedSubjectId);
+                }
+                params.set("returnPath", buildOverviewUrl());
+                router.push(
+                  `/admin/performance-analytics/${studentId}?${params.toString()}`
+                );
+              }}
+            />
+            {students.length > PERFORMANCE_STUDENTS_PAGE_SIZE ? (
+              <Pagination
+                currentPage={currentPage}
+                totalPages={totalStudentPages}
+                onPageChange={setCurrentPage}
+              />
+            ) : null}
+          </div>
       </div>
     );
   };
@@ -532,6 +636,17 @@ const PerformanceAnalyticsPage = () => {
         <p className="text-sm text-zinc-500 mt-0.5">
           Compare student outcomes across classes, terms, and subjects.
         </p>
+        {filtersReady && aggregatedAsOf ? (
+          <p className="mt-2 inline-flex items-center gap-1.5 text-sm text-zinc-600">
+            <IconCalendar size={16} className="shrink-0 text-zinc-400" aria-hidden />
+            <span>
+              Aggregated from tests up to{" "}
+              <strong className="font-semibold text-zinc-800">
+                {formatAggregatedAsOfLabel(aggregatedAsOf)}
+              </strong>
+            </span>
+          </p>
+        ) : null}
       </div>
 
       {/* Filters */}
@@ -595,6 +710,20 @@ const PerformanceAnalyticsPage = () => {
               onChange={(v) => updateFilters({ selectedScoreRange: v ?? "" })}
               leftSection={filterIcon}
               allowDeselect={false}
+            />
+          </div>
+          <div className="flex-1 min-w-[170px]">
+            <TextInput
+              label="Aggregated As Of"
+              type="date"
+              value={aggregatedAsOf}
+              max={getTodayDateInputValue()}
+              classNames={filterFieldClassNames}
+              onChange={(e) => {
+                const next = e.currentTarget.value;
+                if (!next || !isValidDateInput(next)) return;
+                updateFilters({ aggregatedAsOf: next });
+              }}
             />
           </div>
           <button

--- a/frontend/src/components/admin/performance/PerformanceBreakdownTable.tsx
+++ b/frontend/src/components/admin/performance/PerformanceBreakdownTable.tsx
@@ -11,6 +11,7 @@ import {
   ordinal,
 } from "./performanceClusters";
 import ClusterBadge from "./ClusterBadge";
+import { formatPercent, roundPercent } from "@/utils/formatPercent";
 
 interface PerformanceBreakdownTableProps {
   students: ClassSubjectPerformanceStudent[];
@@ -94,14 +95,14 @@ export const PerformanceBreakdownTable: React.FC<
             ) : (
               <div className="flex items-center gap-3">
                 <Progress
-                  value={score}
+                  value={roundPercent(score)}
                   color={clusterStyle?.progressColor ?? "violet"}
                   radius="xl"
                   size="sm"
                   className="w-24 shrink-0"
                 />
                 <span className="text-sm font-semibold text-zinc-800 tabular-nums w-10 text-right">
-                  {Math.round(score)}%
+                  {formatPercent(score)}
                 </span>
               </div>
             )}

--- a/frontend/src/components/admin/performance/ScoreDistributionChart.tsx
+++ b/frontend/src/components/admin/performance/ScoreDistributionChart.tsx
@@ -5,6 +5,7 @@ import { Tooltip } from "@mantine/core";
 import { useElementSize } from "@mantine/hooks";
 import type { ClassSubjectPerformanceStudent } from "@/@types";
 import { CLUSTER_STYLES } from "./performanceClusters";
+import { formatPercent, roundPercent } from "@/utils/formatPercent";
 
 const DOT_W = 18; // dot width (px)
 const DOT_H = 18; // dot height (px)
@@ -104,7 +105,7 @@ export default function ScoreDistributionChart({
               className="absolute -translate-x-1/2 whitespace-nowrap text-xs font-medium text-violet-600"
               style={{ left: xFor(median), top: 0 }}
             >
-              Median {Math.round(median)}%
+              Median {formatPercent(median, "")}
             </div>
           </>
         )}
@@ -133,7 +134,7 @@ export default function ScoreDistributionChart({
               label={
                 <div className="text-xs leading-relaxed">
                   <p className="font-semibold">{student.studentName}</p>
-                  <p>Score: {student.aggregatedScore}%</p>
+                  <p>Score: {formatPercent(student.aggregatedScore)}</p>
                   <p>{student.cluster ?? "Unranked"}</p>
                 </div>
               }
@@ -162,7 +163,7 @@ export default function ScoreDistributionChart({
           <span>
             Class average:{" "}
             <span className="font-semibold text-zinc-700">
-              {Math.round(classAverage)}%
+              {formatPercent(classAverage)}
             </span>
           </span>
         )}

--- a/frontend/src/components/admin/performance/ScoreDistributionChart.tsx
+++ b/frontend/src/components/admin/performance/ScoreDistributionChart.tsx
@@ -5,7 +5,7 @@ import { Tooltip } from "@mantine/core";
 import { useElementSize } from "@mantine/hooks";
 import type { ClassSubjectPerformanceStudent } from "@/@types";
 import { CLUSTER_STYLES } from "./performanceClusters";
-import { formatPercent, roundPercent } from "@/utils/formatPercent";
+import { formatPercent } from "@/utils/formatPercent";
 
 const DOT_W = 18; // dot width (px)
 const DOT_H = 18; // dot height (px)

--- a/frontend/src/components/common/StudentPerformanceAnalytics.tsx
+++ b/frontend/src/components/common/StudentPerformanceAnalytics.tsx
@@ -19,6 +19,7 @@ import type {
 import NoAvailableEmptyState from "@/components/common/NoAvailableEmptyState";
 import { TermFilterCard } from "@/components/common/TermFilterCard";
 import { getSortedSchoolTerms } from "@/utils/schoolTerms";
+import { formatPercent, roundPercent } from "@/utils/formatPercent";
 
 function formatTs(iso: string) {
   const d = dayjs(iso);
@@ -51,7 +52,7 @@ function AssignmentGradeRow({ row }: { row: TopicAssignmentGradeDetail }) {
         <div className="flex shrink-0 flex-col items-start gap-2 sm:items-end">
           <Badge variant="filled" color="violet" size="lg" radius="sm">
             {row.score} / {row.maxScore}{" "}
-            <span className="opacity-90">({row.percentage}%)</span>
+            <span className="opacity-90">({formatPercent(row.percentage, "")})</span>
           </Badge>
           <div className="flex flex-wrap justify-end gap-1.5">
             <Badge variant="outline" color="gray" size="xs">
@@ -152,7 +153,7 @@ const StudentPerformanceAnalytics: React.FC<
           s.subjectName.length > 22
             ? `${s.subjectName.slice(0, 20)}…`
             : s.subjectName,
-        Average: s.averagePercent as number,
+        Average: roundPercent(s.averagePercent as number),
       }));
   }, [analytics]);
 
@@ -209,7 +210,7 @@ const StudentPerformanceAnalytics: React.FC<
               title="Assignments average"
               value={
                 analytics.summary.assignmentAveragePercent != null
-                  ? `${analytics.summary.assignmentAveragePercent}%`
+                  ? formatPercent(analytics.summary.assignmentAveragePercent)
                   : "0%"
               }
               subtitle="Graded submissions for this term"
@@ -288,9 +289,7 @@ const StudentPerformanceAnalytics: React.FC<
                           <span>{subj.gradedCount} graded</span>
                           <Badge variant="light" color="indigo" size="xs">
                             Avg{" "}
-                            {subj.averagePercent != null
-                              ? `${subj.averagePercent}%`
-                              : "—"}
+                            {formatPercent(subj.averagePercent)}
                           </Badge>
                         </div>
                       </div>
@@ -311,12 +310,12 @@ const StudentPerformanceAnalytics: React.FC<
                                 <span className="text-zinc-600">
                                   {t.gradedCount} graded
                                   {t.averagePercent != null
-                                    ? ` · avg ${t.averagePercent}%`
+                                    ? ` · avg ${formatPercent(t.averagePercent)}`
                                     : ""}
                                 </span>
                               </div>
                               <Progress
-                                value={t.averagePercent ?? 0}
+                                value={roundPercent(t.averagePercent ?? 0)}
                                 color="violet"
                                 radius="xl"
                                 size="sm"

--- a/frontend/src/hooks/school-admin.ts
+++ b/frontend/src/hooks/school-admin.ts
@@ -1508,6 +1508,7 @@ export type ClassSubjectPerformanceFilters = {
   cluster?: PerformanceCluster;
   scoreRangeMin?: number;
   scoreRangeMax?: number;
+  aggregatedAsOf?: string;
 };
 
 export const useGetClassSubjectPerformance = (
@@ -1521,6 +1522,7 @@ export const useGetClassSubjectPerformance = (
     cluster,
     scoreRangeMin,
     scoreRangeMax,
+    aggregatedAsOf,
   } = filters;
 
   const { data, isLoading, isFetching, refetch } = useQuery({
@@ -1534,6 +1536,7 @@ export const useGetClassSubjectPerformance = (
         params.set("scoreRangeMin", String(scoreRangeMin));
       if (scoreRangeMax !== undefined)
         params.set("scoreRangeMax", String(scoreRangeMax));
+      if (aggregatedAsOf) params.set("aggregatedAsOf", aggregatedAsOf);
 
       return customAPI.get(
         `/school-admin/classes/${classLevelId}/subject-performance?${params.toString()}`

--- a/frontend/src/utils/formatPercent.ts
+++ b/frontend/src/utils/formatPercent.ts
@@ -1,0 +1,23 @@
+/** Round a percentage value to a whole number (0–100 scale). */
+export function roundPercent(value: number): number {
+  return Math.round(value);
+}
+
+/** Format a percentage for display, e.g. `63%`. */
+export function formatPercent(
+  value: number | null | undefined,
+  fallback = "—",
+): string {
+  if (value === null || value === undefined) return fallback;
+  return `${roundPercent(value)}%`;
+}
+
+/** Format a min–max percentage range, e.g. `45%–82%`. */
+export function formatPercentRange(
+  min: number | null,
+  max: number | null,
+  fallback = "—",
+): string {
+  if (min === null || max === null) return fallback;
+  return `${roundPercent(min)}%–${roundPercent(max)}%`;
+}


### PR DESCRIPTION
Add date filter and label so leaderboard scores reflect graded work through a chosen day. Also switch analytics averages to point-weightedscoring with whole-number display and paginate the student breakdown table